### PR TITLE
Fixes issue with an undefined variable in MTaSPUs

### DIFF
--- a/R/MTaSPUs.R
+++ b/R/MTaSPUs.R
@@ -47,7 +47,7 @@
 
 MTaSPUs <- function(Z, r, B, pow, tranform = FALSE){
     if (tranform){
-        v <- ginv(v)
+        v <- ginv(r)
         Z <- tcrossprod(Z, v)
     }
 
@@ -58,7 +58,7 @@ MTaSPUs <- function(Z, r, B, pow, tranform = FALSE){
     }
 
     set.seed(1000)
-    Z0 <- rmvnorm(B, mean = rep(0, nrow(v)), sigma = v)
+    Z0 <- rmvnorm(B, mean = rep(0, nrow(r)), sigma = r)
     pval <- matrix(0, N, length(pow)+1)
 
     ponum <- pow[pow < Inf]


### PR DESCRIPTION
I had a problem running the MTaSPUs function unless a variable 'v' was assigned to the estimated covariance matrix before the call, now used the covariance matrix ('r') passed to MTaSPUs instead.
